### PR TITLE
Fix toArray not defined issue.

### DIFF
--- a/src/Traits/EntityTrait.php
+++ b/src/Traits/EntityTrait.php
@@ -7,8 +7,8 @@ namespace Equip\Data\Traits;
  */
 trait EntityTrait
 {
-    use ImmutableValueObjectTrait;
     use DateAwareTrait;
     use JsonAwareTrait;
     use SerializeAwareTrait;
+    use ImmutableValueObjectTrait;
 }


### PR DESCRIPTION
Intelephense complains that toArray is not implemented, because SerializeAwareTrait has toArray as abstract, and ImmutableValueObjectTrait is defined before it, thus the abstract overrides the definition as far as static analysis goes. PHPStan understands this, but intelephense doesn't.